### PR TITLE
Fix view component

### DIFF
--- a/src/Client/Menu.fs
+++ b/src/Client/Menu.fs
@@ -29,9 +29,8 @@ let containerStyle (margin : int) = [
     style.marginLeft margin
 ]
 
-let view content =
-    {| content = content |} // have to wrap in an object here, using the seq directly errors
-    |> React.functionComponent(fun (props: {| content : ReactElement seq |}) ->
+let view' = 
+    React.functionComponent(fun (props: {| content : ReactElement seq |}) ->
         let (isOpen, setOpen) = React.useState(false)
         Html.div [
             Html.div [
@@ -50,3 +49,6 @@ let view content =
             ]
         ]) 
     
+// have to wrap in an object here, using the seq directly errors
+let inline view content = view' {| content = content |}
+


### PR DESCRIPTION
I saw [your blog post](https://www.compositional-it.com/news-blog/stateful-react-components/), and noticed this minor issue. When using the `React.functionComponent` syntax, components need to not be a function. This is because the internal state (if the menu is open) will be reset when the function is evaluated (when the model changes).